### PR TITLE
Refactor dev setup to create Metabase database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,12 @@ setup-metabase: setup-db ## Setups Metabase which depends on setting up the Post
 .PHONY: setup-db
 setup-db: ## Sets up the Postgres database using docker compose and creates a database named metabase
 	@\
-	docker-compose up -d database; \
-	DATABASE_CONTAINER_ID=$$(docker ps -a --filter "name=database"  --format "{{.ID}}"); \
-	echo $$DATABASE_CONTAINER_ID; \
-	sleep 10; \
-	docker exec -it $$DATABASE_CONTAINER_ID psql -U root dbt --command "CREATE DATABASE metabase";
+	docker-compose up -d database
 
 .PHONY: db-connect
 db-connect: 
 	DATABASE_CONTAINER_ID=$$(docker ps -a --filter "name=database"  --format "{{.ID}}"); \
-	docker exec -it $$DATABASE_CONTAINER_ID psql -U root dbt
-
-
+	docker exec -it $$DATABASE_CONTAINER_ID psql -U root metabase
 
 .PHONY: down
 down: ## Brings down all the docker containers using docker-compose

--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ make down
 ```sh
 docker-compose down
 ```
+
+## Running dbt locally
+
+The Metabase Docker image will always build the Metabase internal database in the "public" schema of the "metabase" database in Postgres.
+
+Therefore you will need to overide the **metabase_schema** var when running locally.
+
+```bash
+dbt run --select +metabase_download_activity --vars '{"metabase_schema": "public"}'
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       POSTGRES_USER: "root"
       POSTGRES_PASSWORD: "password"
-      POSTGRES_DB: "dbt"
+      POSTGRES_DB: "metabase"
     ports:
       - "5432:5432"
   metabase:

--- a/models/_metabase_sources.yml
+++ b/models/_metabase_sources.yml
@@ -2,8 +2,8 @@ version: 2
 
 sources:
   - name: metabase
-    schema: "{{ var('metabase_schema', 'metabase') }}"
     database: "{% if target.type != 'spark'%}{{ var('metabase_database', target.database) }}{% endif %}"
+    schema: "{{ var('metabase_schema', target.schema) }}"
     tables:
       - name: activity
       - name: application_permissions_revision


### PR DESCRIPTION
- Refactors the docker-compose and Make files to remove reference to a **dbt** database and removes the need to create the "metabase" database using the **setup-db** make command.

- The "metabase" database is now created in the docker-compose file through environment variables.
